### PR TITLE
Bugfix/usebasicparsing

### DIFF
--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -73,7 +73,7 @@ Function Save-LatestUpdate {
                 Else {
                     # BITS isn't available (likely PowerShell Core)
                     If ( $pscmdlet.ShouldProcess($url, "WebDownload") ) {
-                        Invoke-WebRequest -Uri $url -OutFile $target
+                        Invoke-WebRequest -Uri $url -OutFile $target -UseBasicParsing
                     }
                 }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.1.0.38
+
+### Public Functions
+
+- Modified `Invoke-WebRequest` calls within `Get-LatestUpdate` and `Save-LatestUpdate` to use the `UseBasicParsing` parameter, removing the reliance on Internet Explorer, and enabling the script to work in PowerShell 6
+
 ## v1.1.0.37
 
 ### Public Functions


### PR DESCRIPTION
# Description

The current implementation of this script calls Invoke-WebRequest without the -UseBasicParsing parameter. The implications are twofold:

- The script does not work with certain states of Internet Explorer (i.e. when the first run wizard has not been completed)
- The script does not work without Internet Explorer (i.e. in Windows Server Core)
- The script will not work in PowerShell 6

## Related Issue

https://github.com/aaronparker/LatestUpdate/issues/14

## Motivation and Context

Our usage is to run the script in TeamCity, which uses a System account. This script won't work in our scenario as the System account will never have its IE configured.

## How Has This Been Tested?

* Tested on Windows 10 in our scenario mentioned above

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
