### PR TITLE
Development

### DIFF
--- a/LatestUpdate/LatestUpdate.psd1
+++ b/LatestUpdate/LatestUpdate.psd1
@@ -12,7 +12,7 @@
 RootModule = 'LatestUpdate.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.3.1.81'
+ModuleVersion = '2.4.0.81'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -103,7 +103,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'Windows10','WindowsServer2019','WindowsServer2016','CumulativeUpdate','AdobeFlash','LatestUpdate','MDT','MicrosoftDeploymentToolkit','MonthlyUpdate','ServicingStack'
+        Tags = 'Windows10','WindowsServer2019','WindowsServer2016','CumulativeUpdate','AdobeFlash','Adobe','Flash','LatestUpdate','MDT','MicrosoftDeploymentToolkit','MonthlyUpdate','ServicingStack'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/aaronparker/LatestUpdate/blob/master/LICENSE'

--- a/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
+++ b/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
@@ -42,34 +42,46 @@ Function Get-UpdateDownloadArray {
             Write-Verbose -Message "Adding $url to output."
             $newItem = New-Object PSObject
             $newItem | Add-Member -type NoteProperty -Name 'KB' -Value $idItem.KB
-            $newItem | Add-Member -type NoteProperty -Name 'Arch' `
-                -Value (Get-RxString -String $idItem.Note -RegEx $rxArch)
 
-            # Add custom version note based on description returned from page
+            # Add custom version note and check architecture based on description returned from page
+            $arch = Get-RxString -String $idItem.Note -RegEx $rxArch
             If ($idItem.Note -match "Windows 10.*") {
                 $Version = Get-RxString -String $idItem.Note -RegEx $rx10
+                If ($Null -eq $arch) { $arch = "x86" }
+            }
+            ElseIf ($idItem.Note -match "Windows Server 2016") {
+                $Version = "1607"
+                If ($Null -eq $arch) { $arch = "x64" }
             }
             ElseIf ($idItem.Note -match $rx2012) {
                 $Version = "2012"
+                If ($Null -eq $arch) { $arch = "x64" }
             }
             ElseIf ($idItem.Note -match "Windows Server 2012 R2") {
                 $Version = "2012R2"
+                If ($Null -eq $arch) { $arch = "x64" }
             }
             ElseIf ($idItem.Note -match "Windows 8.1") {
                 $Version = "8.1"
+                If ($Null -eq $arch) { $arch = "x86" }
             }
             ElseIf ($idItem.Note -match "Windows Embedded 8 Standard") {
                 $Version = "8Embedded"
+                If ($Null -eq $arch) { $arch = "x86" }
             }
             ElseIf ($idItem.Note -match "Windows Server 2008 R2") {
                 $Version = "2008R2"
+                If ($Null -eq $arch) { $arch = "x64" }
             }
             ElseIf ($idItem.Note -match "Windows 7") {
                 $Version = "7"
+                If ($Null -eq $arch) { $arch = "x86" }
             }
             ElseIf ($idItem.Note -match "Windows Embedded Standard 7") {
                 $Version = "7Embedded"
+                If ($Null -eq $arch) { $arch = "x86" }
             }
+            $newItem | Add-Member -type NoteProperty -Name 'Arch' -Value $arch
             $newItem | Add-Member -type NoteProperty -Name 'Version' -Value $Version
 
             $newItem | Add-Member -type NoteProperty -Name 'Note' -Value $idItem.Note
@@ -83,6 +95,7 @@ Function Get-UpdateDownloadArray {
             }
             $newItem | Add-Member -type NoteProperty -Name 'URL' -Value $download
 
+            # Add item to the output array
             $output += $newItem
         }
     }

--- a/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
+++ b/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
@@ -45,6 +45,7 @@ Function Get-UpdateDownloadArray {
             $newItem | Add-Member -type NoteProperty -Name 'Arch' `
                 -Value (Get-RxString -String $idItem.Note -RegEx $rxArch)
 
+            # Add custom version note based on description returned from page
             If ($idItem.Note -match "Windows 10.*") {
                 $Version = Get-RxString -String $idItem.Note -RegEx $rx10
             }
@@ -72,7 +73,11 @@ Function Get-UpdateDownloadArray {
             $newItem | Add-Member -type NoteProperty -Name 'Version' -Value $Version
 
             $newItem | Add-Member -type NoteProperty -Name 'Note' -Value $idItem.Note
-            $newItem | Add-Member -type NoteProperty -Name 'URL' -Value $url
+
+            # Filter URL to ensure only .MSU updates are returned
+            $download = $url | Where-Object { (Split-Path -Path $_ -Extension) -match ".msu" }
+            $newItem | Add-Member -type NoteProperty -Name 'URL' -Value $download
+
             $output += $newItem
         }
     }

--- a/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
+++ b/LatestUpdate/Private/Get-UpdateDownloadArray.ps1
@@ -75,7 +75,12 @@ Function Get-UpdateDownloadArray {
             $newItem | Add-Member -type NoteProperty -Name 'Note' -Value $idItem.Note
 
             # Filter URL to ensure only .MSU updates are returned
-            $download = $url | Where-Object { (Split-Path -Path $_ -Extension) -match ".msu" }
+            If (Test-PSCore) {
+                $download = $url | Where-Object { (Split-Path -Path $_ -Extension) -match ".msu" }
+            }
+            Else {
+                $download = $url | Where-Object { ([IO.Path]::GetExtension($_)) -match ".msu" }
+            }
             $newItem | Add-Member -type NoteProperty -Name 'URL' -Value $download
 
             $output += $newItem

--- a/LatestUpdate/Private/New-MdtPackagesFolder.ps1
+++ b/LatestUpdate/Private/New-MdtPackagesFolder.ps1
@@ -21,10 +21,9 @@ Function New-MdtPackagesFolder {
         [Parameter(Mandatory = $True, Position = 1, ValueFromPipeline = $True)]
         [String] $Path
     )
-    If ((Test-Path -Path "$($Drive):\Packages\$Path" -Type 'Container')) {
-        Write-Output $True
-    }
-    Else {
+
+    # If $Path does not exist, attempt to create it
+    If (!(Test-Path -Path "$($Drive):\Packages\$Path" -Type 'Container')) {
         If ($pscmdlet.ShouldProcess("$($Drive):\Packages\$Path", "Creating")) {
             Write-Verbose "Creating folder $($Drive):\Packages\$($Path)."
             Try {
@@ -35,7 +34,12 @@ Function New-MdtPackagesFolder {
             Catch {
                 Throw "Failed to create Packages folder."
             }
+
+            # Return status from New-Item
             Write-Output $?
         }
+    }
+    Else {
+        Write-Verbose "Path exists: $($Drive):\Packages\$Path"
     }
 }

--- a/LatestUpdate/Private/New-MdtPackagesFolder.ps1
+++ b/LatestUpdate/Private/New-MdtPackagesFolder.ps1
@@ -22,13 +22,17 @@ Function New-MdtPackagesFolder {
         [String] $Path
     )
 
-    # If $Path does not exist, attempt to create it
-    If (!(Test-Path -Path "$($Drive):\Packages\$Path" -Type 'Container')) {
-
+    # Test path and create if it does not already exist
+    If ((Test-Path -Path "$($Drive):\Packages\$Path" -Type 'Container')) {
+        Write-Verbose "Path exists: $($Drive):\Packages\$Path"
+        Write-Output $True
+    }
+    Else {
         # If path with multiple folders specified, create each one
         $folders = $Path -split "\\"
         $parent = "$($Drive):\Packages"
-        
+               
+        # Walkthrough each folder in the path to create
         ForEach ($folder in $folders) {
             If (!(Test-Path -Path "$parent\$folder" -Type 'Container')) {
                 If ($pscmdlet.ShouldProcess("$parent\$folder", "Creating")) {
@@ -43,12 +47,9 @@ Function New-MdtPackagesFolder {
                 }
             }
             $parent = "$parent\$folder"
-
+        
             # Return status from New-Item
             Write-Output $?
         }
-    }
-    Else {
-        Write-Verbose "Path exists: $($Drive):\Packages\$Path"
     }
 }

--- a/LatestUpdate/Private/New-MdtPackagesFolder.ps1
+++ b/LatestUpdate/Private/New-MdtPackagesFolder.ps1
@@ -1,17 +1,17 @@
 Function New-MdtPackagesFolder {
     <#
-    .SYNOPSIS
-        Creates a folder in the MDT Packages node.
+        .SYNOPSIS
+            Creates a folder in the MDT Packages node.
 
-    .NOTES
-        Author: Aaron Parker
-        Twitter: @stealthpuppy
-    
-    .PARAMETER Drive
-        An existing PS drive letter mapped to an MDT deployment share.
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+        
+        .PARAMETER Drive
+            An existing PS drive letter mapped to an MDT deployment share.
 
-    .PARAMETER Path
-        A new folder to create below the Packages node in the MDT deployment share.
+        .PARAMETER Path
+            A new folder to create below the Packages node in the MDT deployment share.
     #>
     [CmdletBinding(SupportsShouldProcess = $True)]
     Param (
@@ -24,16 +24,25 @@ Function New-MdtPackagesFolder {
 
     # If $Path does not exist, attempt to create it
     If (!(Test-Path -Path "$($Drive):\Packages\$Path" -Type 'Container')) {
-        If ($pscmdlet.ShouldProcess("$($Drive):\Packages\$Path", "Creating")) {
-            Write-Verbose "Creating folder $($Drive):\Packages\$($Path)."
-            Try {
-                New-Item -Path "$($Drive):\Packages" -Enable "True" -Name $Path `
-                    -Comments "Created by 'New-MdtPackagesFolder'" `
-                    -ItemType "Folder"
+
+        # If path with multiple folders specified, create each one
+        $folders = $Path -split "\\"
+        $parent = "$($Drive):\Packages"
+        
+        ForEach ($folder in $folders) {
+            If (!(Test-Path -Path "$parent\$folder" -Type 'Container')) {
+                If ($pscmdlet.ShouldProcess("$parent\$folder", "Creating")) {
+                    Try {
+                        New-Item -Path $parent -Enable "True" -Name $folder `
+                            -Comments "Created by 'New-MdtPackagesFolder'" `
+                            -ItemType "Folder"
+                    }
+                    Catch {
+                        Throw "Failed to create Packages folder."
+                    }
+                }
             }
-            Catch {
-                Throw "Failed to create Packages folder."
-            }
+            $parent = "$parent\$folder"
 
             # Return status from New-Item
             Write-Output $?

--- a/LatestUpdate/Private/Remove-MdtPackage.ps1
+++ b/LatestUpdate/Private/Remove-MdtPackage.ps1
@@ -1,0 +1,44 @@
+Function Remove-MdtPackage {
+    <#
+    .SYNOPSIS
+        Removes all packages from a specified path.
+
+    .NOTES
+        Author: Aaron Parker
+        Twitter: @stealthpuppy
+    
+    .PARAMETER Path
+        Target path that the packages will be removed from.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $True)]
+    Param (
+        [Parameter(Mandatory = $True, Position = 1, ValueFromPipeline = $True)]
+        [String] $Path
+    )
+
+    # Change to the target path
+    Push-Location $Path
+
+    # If change path is successful
+    If ($?) {
+        # Get packages from the current folder
+        $packages = Get-ChildItem | Where-Object { $_.Name -like "Package*" } 
+
+        # Step through each package and remove it
+        ForEach ($package in $packages) {
+            If ($pscmdlet.ShouldProcess($package.Name, "Remove package")) {
+                Try {
+                    # Remove, but don't force in case the update exists in another folder
+                    Write-Verbose -Message "Removing package $($package.Name)"
+                    Remove-Item -Path ".\$($package.Name)"
+                }
+                Catch {
+                    Write-Error "Failed to remove item $($package.Name)"
+                }
+            }
+        }
+
+        # Change back to the original location
+        Pop-Location
+    }
+}

--- a/LatestUpdate/Public/Get-LatestFlash.ps1
+++ b/LatestUpdate/Public/Get-LatestFlash.ps1
@@ -10,7 +10,7 @@ Function Get-LatestFlash {
             Twitter: @stealthpuppy
 
         .LINK
-
+            https://docs.stealthpuppy.com/latestupdate
 
         .EXAMPLE
             Get-LatestUpdate -WindowsVersion Windows7

--- a/LatestUpdate/Public/Get-LatestFlash.ps1
+++ b/LatestUpdate/Public/Get-LatestFlash.ps1
@@ -13,10 +13,10 @@ Function Get-LatestFlash {
             https://docs.stealthpuppy.com/latestupdate
 
         .EXAMPLE
-            Get-LatestUpdate -WindowsVersion Windows7
+            Get-LatestFlash
         
             Description:
-            Enumerate the latest Monthly Update for Windows 7 (and Windows 7 Embedded).
+            Enumerate the latest Adobe Flash Player update for the support versions of Windows.
     #>
     [CmdletBinding(SupportsShouldProcess = $False)]
     Param()

--- a/LatestUpdate/Public/Get-LatestServicingStack.ps1
+++ b/LatestUpdate/Public/Get-LatestServicingStack.ps1
@@ -49,25 +49,28 @@ Function Get-LatestServicingStack {
 
     Process {
         # Step through the servicing stack feed to find the latest KB article for each Windows 10 version
-        ForEach ($vItem in $Version) {
+        ForEach ($ver in $Version) {
 
             # Find the most current date for each entry for each Windows 10 version
-            $date = $servicingStacks | Where-Object { $_.title -match $vItem } | Select-Object -ExpandProperty updated | `
+            $date = $servicingStacks | Where-Object { $_.title -match $ver } | Select-Object -ExpandProperty updated | `
                 ForEach-Object { ([regex]::match($_, $rxM).Groups[1].Value) } | Sort-Object | Select-Object -Last 1
 
             # Return the KB published for that most current date
-            $kbID = $servicingStacks | Where-Object { ($_.title -match $vItem) -and ($_.updated -match $date) } | Select-Object -ExpandProperty id `
-                | ForEach-Object { $_.split(':') | Select-Object -Last 1 }
+            If ($Null -ne $date) {
+                $kbID = $servicingStacks | Where-Object { ($_.title -match $ver) -and ($_.updated -match $date) } | Select-Object -ExpandProperty id `
+                    | ForEach-Object { $_.split(':') | Select-Object -Last 1 }
+            }
 
             # Multiple KBs could be returned, step through each
             ForEach ($id in $kbID) {
 
                 # Read the for updates for that KB from the Microsoft Update Catalog
+                Write-Verbose -Message "Getting update catalog links for KB :$id"
                 $kbObj = Get-UpdateCatalogLink -KB $id
                 If ($Null -ne $kbObj) {
 
                     # Contruct a table with KB, Id and Update description
-                    $idTable = Get-KbUpdateArray -Links $kbObj.Links -KB $kbID
+                    $idTable = Get-KbUpdateArray -Links $kbObj.Links -KB $id
 
                     # Step through the ids for each update
                     ForEach ($idItem in $idTable) {
@@ -96,7 +99,7 @@ Function Get-LatestServicingStack {
                                 $newItem | Add-Member -type NoteProperty -Name 'KB' -Value $idItem.KB
                                 $newItem | Add-Member -type NoteProperty -Name 'Arch' `
                                     -Value (Get-RxString -String $idItem.Note -RegEx "\s+([a-zA-Z0-9]+)-based")
-                                $newItem | Add-Member -type NoteProperty -Name 'Version' -Value $vItem
+                                $newItem | Add-Member -type NoteProperty -Name 'Version' -Value $ver
                                 $newItem | Add-Member -type NoteProperty -Name 'Note' -Value $idItem.Note
                                 $newItem | Add-Member -type NoteProperty -Name 'URL' -Value $url
                                 $output += $newItem

--- a/LatestUpdate/Public/Get-LatestServicingStack.ps1
+++ b/LatestUpdate/Public/Get-LatestServicingStack.ps1
@@ -16,6 +16,7 @@ Function Get-LatestServicingStack {
             Twitter: @stealthpuppy
 
         .LINK
+            https://docs.stealthpuppy.com/latestupdate
 
         .PARAMETER Version
             Windows 10 version to return the Servicing Stack Update for. Use the Year Month notation for Windows 10 versions. Supports 1607+.

--- a/LatestUpdate/Public/Get-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestUpdate.ps1
@@ -19,7 +19,7 @@ Function Get-LatestUpdate {
             Forked from: https://gist.github.com/keithga/1ad0abd1f7ba6e2f8aff63d94ab03048
 
         .LINK
-            https://support.microsoft.com/en-au/help/4464619
+            https://docs.stealthpuppy.com/latestupdate
 
         .PARAMETER WindowsVersion
             Specifiy the Windows version to search for updates. Valid values are Windows10, Windows8, Windows7 (applies to desktop and server editions).

--- a/LatestUpdate/Public/Get-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestUpdate.ps1
@@ -70,7 +70,7 @@ Function Get-LatestUpdate {
         [String] $WindowsVersion = "Windows10",
 
         [Parameter(Mandatory = $False, Position = 1, HelpMessage = "Provide a Windows 10 build number")]
-        [ValidateSet('17763', '17134', '16299', '15063', '14393', '10586', '10240', '^(?!.*Preview)(?=.*Monthly).*')]
+        [ValidateSet('17763', '17134', '16299', '15063', '14393', '10240', '^(?!.*Preview)(?=.*Monthly).*')]
         [String] $Build = "17763"
     )
     Begin {

--- a/LatestUpdate/Public/Import-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Import-LatestUpdate.ps1
@@ -94,16 +94,9 @@ Function Import-LatestUpdate {
         }
         Write-Verbose "Destination is $($dest)"
 
-        # If -Clean is specified, enumerate existing packages from the target destination and remove before importing
+        # If -Clean is specified, remove packages from the destination folder
         If ($Clean) {
-            Push-Location $dest
-            Get-ChildItem | Where-Object { $_.Name -like "Package*" } | ForEach-Object { 
-                If ( $pscmdlet.ShouldProcess($_.Name, "Remove package") ) {
-                    # Remove, but don't force in case the update exists in another folder
-                    Remove-Item $_.Name
-                }
-            }
-            Pop-Location
+            Remove-MdtPackage -Path $dest
         }
 
         # Validate the provided local path and import the update package

--- a/LatestUpdate/Public/Import-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Import-LatestUpdate.ps1
@@ -11,7 +11,7 @@ Function Import-LatestUpdate {
         Twitter: @stealthpuppy
 
     .LINK
-        http://stealthpuppy.com
+        https://docs.stealthpuppy.com/latestupdate
 
     .PARAMETER UpdatePath
         The folder containing the updates to import into the MDT deployment share.

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -15,6 +15,9 @@ Function Save-LatestUpdate {
             Author: Aaron Parker
             Twitter: @stealthpuppy
 
+        .LINK
+            https://docs.stealthpuppy.com/latestupdate
+
         .PARAMETER Updates
             The array of latest cumulative updates retreived by Get-LatestUpdate.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@
 build: off
 
 # Version number
-version: 2.3.1.{build}
+version: 2.4.0.{build}
 
 # There's no need to alter the build number for a Pull Request (PR) since they don't modify anything
 pull_requests:

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -68,14 +68,6 @@ Describe 'Get-LatestUpdate' {
                 $Update.Version -match "1607" | Should -Not -BeNullOrEmpty
             }
         }
-        It "Given '10586' returns updates for build 1511" {
-            $Updates = Get-LatestUpdate -WindowsVersion Windows10 -Build '10586'
-            ForEach ($Update in $Updates) {
-                $Update.Note -match "Cumulative.*1511" | Should -Not -BeNullOrEmpty
-                $Update.Arch -match "x86|x64|ARM64" | Should -Not -BeNullOrEmpty
-                $Update.Version -match "1511" | Should -Not -BeNullOrEmpty
-            }
-        }
         It "Given '10240' returns updates for build 1507" {
             $Updates = Get-LatestUpdate -WindowsVersion Windows10 -Build '10240'
             ForEach ($Update in $Updates) {


### PR DESCRIPTION
# Description

* Account for missing architecture and version strings in `Get-LatestFlash`
* Update LINK in comments in public functions
* Fix an issue where stepping through multiple KBs was not handled correctly in `Get-LatestServicingStack`
* Add additional error checking to `Get-LatestServicingStack`
* Remove support for Windows 10 1511 (build 10586) in `Get-LatestUpdate` as updates for this build are no longer available in the update feed
* Update private function `Get-UpdateDownloadArray` to fix download URLs returned for .MSU and .EXE updaters for Windows 7
* Update logic in private function `New-MdtPackagesFolder` to cater for multiple paths (e.g. parent\child). Enables `Import-LatestUpdate` to create packages folders such as "Windows 10\1803"
* Update code to fix removing existing packages with -Clean in `Import-LatestUpdate`

## Related Issue

* Issue #30 
* Issue #29 
* Issue #27 
* Issue #23 

## How Has This Been Tested?

* Tested on Windows 10 & macOS

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
