### PR TITLE
Add Revision property

### DIFF
--- a/LatestUpdate/Private/Add-Property.ps1
+++ b/LatestUpdate/Private/Add-Property.ps1
@@ -10,29 +10,31 @@ Function Add-Property {
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSObject] $InputObject,
 
-        [Parameter(Mandatory = $True, Position = 1, ValueFromPipeline)]
+        [Parameter(Mandatory = $True, Position = 1)]
         [ValidateNotNullOrEmpty()]
         [System.String] $Property,
 
-        [Parameter(Mandatory = $True, Position = 2, ValueFromPipeline)]
+        [Parameter(Mandatory = $True, Position = 2)]
         [ValidateNotNullOrEmpty()]
         [System.String] $NewPropertyName,
 
-        [Parameter(Mandatory = $True, Position = 3, ValueFromPipeline)]
+        [Parameter(Mandatory = $True, Position = 3)]
         [ValidateNotNullOrEmpty()]
         [System.String] $MatchPattern
     )
 
-    ForEach ($object in $InputObject) {
-        $value = $object | Select-Object -ExpandProperty $Property | `
-            Select-String -AllMatches -Pattern $MatchPattern | `
-            ForEach-Object { $_.Matches.Value }
+    Process {
+        ForEach ($object in $InputObject) {
+            $value = $object | Select-Object -ExpandProperty $Property | `
+                Select-String -AllMatches -Pattern $MatchPattern | `
+                ForEach-Object { $_.Matches.Value }
         
-        If ($value.Count -ge 2) {
-            $value = $value | Select-Object -Last 1
-        }
+            If ($value.Count -ge 2) {
+                $value = $value | Select-Object -Last 1
+            }
 
-        $object | Add-Member -NotePropertyName $NewPropertyName -NotePropertyValue $value
-        Write-Output -InputObject $object
+            $object | Add-Member -NotePropertyName $NewPropertyName -NotePropertyValue $value
+            Write-Output -InputObject $object
+        }
     }
 }

--- a/LatestUpdate/Private/ConvertTo-Hashtable.ps1
+++ b/LatestUpdate/Private/ConvertTo-Hashtable.ps1
@@ -11,7 +11,7 @@ Function ConvertTo-Hashtable {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline)]
-        [System.Management.Automation.PSObject] $InputObject
+        $InputObject
     )
 
     Process {

--- a/LatestUpdate/Private/ConvertTo-Hashtable.ps1
+++ b/LatestUpdate/Private/ConvertTo-Hashtable.ps1
@@ -7,11 +7,11 @@ Function ConvertTo-Hashtable {
             Author: Adam Bertram
             Link: https://4sysops.com/archives/convert-json-to-a-powershell-hash-table
     #>
+    [OutputType([System.Collections.Hashtable])]
     [CmdletBinding()]
-    [OutputType('hashtable')]
     Param (
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline)]
-        $InputObject
+        [System.Management.Automation.PSObject] $InputObject
     )
 
     Process {
@@ -41,12 +41,12 @@ Function ConvertTo-Hashtable {
             ForEach ($property in $InputObject.PSObject.Properties) {
                 $hash[$property.Name] = ConvertTo-Hashtable -InputObject $property.Value
             }
-            $hash
+            Write-Output -InputObject $hash
         }
         Else {
             ## If the object isn't an array, collection, or other object, it's already a hash table
             ## So just return it.
-            $InputObject
+            Write-Output -InputObject $InputObject
         }
     }
 }

--- a/LatestUpdate/Private/ConvertTo-Hashtable.ps1
+++ b/LatestUpdate/Private/ConvertTo-Hashtable.ps1
@@ -41,12 +41,12 @@ Function ConvertTo-Hashtable {
             ForEach ($property in $InputObject.PSObject.Properties) {
                 $hash[$property.Name] = ConvertTo-Hashtable -InputObject $property.Value
             }
-            Write-Output -InputObject $hash
+            $hash
         }
         Else {
             ## If the object isn't an array, collection, or other object, it's already a hash table
             ## So just return it.
-            Write-Output -InputObject $InputObject
+            $InputObject
         }
     }
 }

--- a/LatestUpdate/Private/Get-ModuleResource.ps1
+++ b/LatestUpdate/Private/Get-ModuleResource.ps1
@@ -6,7 +6,7 @@ Function Get-ModuleResource {
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
     Param (
-        [Parameter(Mandatory = $False, Position = 0, ValueFromPipeline)]
+        [Parameter(Mandatory = $False, Position = 0)]
         [ValidateNotNull()]
         [ValidateScript( { If (Test-Path -Path $_ -PathType 'Leaf') { $True } Else { Throw "Cannot find file $_" } })]
         [System.String] $Path = (Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath "LatestUpdate.json")

--- a/LatestUpdate/Private/Get-UpdateAdobeFlash.ps1
+++ b/LatestUpdate/Private/Get-UpdateAdobeFlash.ps1
@@ -10,7 +10,7 @@ Function Get-UpdateAdobeFlash {
         [ValidateNotNullOrEmpty()]
         [System.Xml.XmlNode] $UpdateFeed,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, Position = 1)]
         [System.Management.Automation.SwitchParameter] $Previous
     )
 

--- a/LatestUpdate/Private/Get-UpdateCatalogDownloadInfo.ps1
+++ b/LatestUpdate/Private/Get-UpdateCatalogDownloadInfo.ps1
@@ -6,18 +6,18 @@ Function Get-UpdateCatalogDownloadInfo {
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $True)]
+        [Parameter(Mandatory = $True, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [System.String] $UpdateId,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, Position = 1)]
         [System.String] $Architecture,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, Position = 2)]
         [Alias('OS')]
         [System.String] $OperatingSystem = $script:resourceStrings.ParameterValues.Windows10,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, Position = 3)]
         [System.String] $SearchString
     )
 

--- a/LatestUpdate/Private/Invoke-UpdateCatalogDownloadDialog.ps1
+++ b/LatestUpdate/Private/Invoke-UpdateCatalogDownloadDialog.ps1
@@ -6,7 +6,7 @@ Function Invoke-UpdateCatalogDownloadDialog {
     [OutputType([Microsoft.PowerShell.Commands.WebResponseObject])]
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $True)]
+        [Parameter(Mandatory = $True, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [System.Collections.Hashtable] $Body
     )

--- a/LatestUpdate/Private/Invoke-UpdateCatalogSearch.ps1
+++ b/LatestUpdate/Private/Invoke-UpdateCatalogSearch.ps1
@@ -6,11 +6,11 @@ Function Invoke-UpdateCatalogSearch {
     [OutputType([Microsoft.PowerShell.Commands.WebResponseObject])]
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $True)]
+        [Parameter(Mandatory = $True, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [System.String] $UpdateId,
 
-        [Parameter(Mandatory = $False)]
+        [Parameter(Mandatory = $False, Position = 1)]
         [System.String] $SearchString
     )
 

--- a/LatestUpdate/Private/Test-PSCore.ps1
+++ b/LatestUpdate/Private/Test-PSCore.ps1
@@ -6,7 +6,7 @@ Function Test-PSCore {
     [CmdletBinding()]
     [OutputType([Boolean])]
     Param (
-        [Parameter(Mandatory = $False, Position = 0, ValueFromPipeline)]
+        [Parameter(Mandatory = $False, Position = 0)]
         [ValidateNotNullOrEmpty()]
         [System.String] $Version = '6.0.0'
     )

--- a/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
@@ -63,6 +63,7 @@ Function Get-LatestAdobeFlashUpdate {
         # Get the update feed and continue if successfully read
         Write-Verbose -Message "$($MyInvocation.MyCommand): get feed for $OperatingSystem."
         $updateFeed = Get-UpdateFeed -Uri $script:resourceStrings.UpdateFeeds.$OperatingSystem
+
         If ($Null -ne $updateFeed) {
 
             # Filter the feed for Adobe Flash updates and continue if we get updates
@@ -78,6 +79,7 @@ Function Get-LatestAdobeFlashUpdate {
 
                     "Windows10" {
                         ForEach ($ver in $Version) {
+
                             # Get download info for each update from the catalog
                             Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($update.Title)]."
                             $downloadInfoParams = @{

--- a/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
@@ -96,13 +96,14 @@ Function Get-LatestCumulativeUpdate {
                         MatchPattern    = $script:resourceStrings.Matches.Architecture
                     }
                     $updateListWithArch = Add-Property @updateListWithArchParams
-
+                    $updateListWithArch | Add-Member -NotePropertyName "Revision" -NotePropertyValue "$($updateList.Build).$($updateList.Revision)"
                     # Return object to the pipeline
                     If ($Null -ne $updateListWithArch) {
                         Write-Output -InputObject $updateListWithArch
                     }
                 }
             }
+
         }
     }
 }

--- a/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
@@ -55,6 +55,7 @@ Function Get-LatestCumulativeUpdate {
     
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {
+
         # Get the update feed and continue if successfully read
         Write-Verbose -Message "$($MyInvocation.MyCommand): get feed for $OperatingSystem."
         $updateFeed = Get-UpdateFeed -Uri $script:resourceStrings.UpdateFeeds.Windows10
@@ -73,6 +74,7 @@ Function Get-LatestCumulativeUpdate {
                 Write-Verbose -Message "$($MyInvocation.MyCommand): update count is: $($updateList.Count)."
 
                 If ($Null -ne $updateList) {
+
                     # Get download info for each update from the catalog
                     Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($updateList.Title)]."
                     $downloadInfoParams = @{
@@ -96,7 +98,10 @@ Function Get-LatestCumulativeUpdate {
                         MatchPattern    = $script:resourceStrings.Matches.Architecture
                     }
                     $updateListWithArch = Add-Property @updateListWithArchParams
+
+                    # Add Revsion property
                     $updateListWithArch | Add-Member -NotePropertyName "Revision" -NotePropertyValue "$($updateList.Build).$($updateList.Revision)"
+
                     # Return object to the pipeline
                     If ($Null -ne $updateListWithArch) {
                         Write-Output -InputObject $updateListWithArch

--- a/LatestUpdate/Public/Get-LatestNetFrameworkUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestNetFrameworkUpdate.ps1
@@ -33,6 +33,7 @@ Function Get-LatestNetFrameworkUpdate {
 
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {
+
         # Get the update feed and continue if successfully read
         $updateFeed = Get-UpdateFeed -Uri $script:resourceStrings.UpdateFeeds.NetFramework
 
@@ -51,6 +52,7 @@ Function Get-LatestNetFrameworkUpdate {
 
             If ($Null -ne $updateList) {
                 ForEach ($update in $updateList) {
+
                     # Get download info for each update from the catalog
                     Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($update.Title)]."
                     $downloadInfoParams = @{

--- a/LatestUpdate/Public/Get-LatestServicingStackUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestServicingStackUpdate.ps1
@@ -49,6 +49,7 @@ Function Get-LatestServicingStackUpdate {
 
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {
+
         # Get the update feed and continue if successfully read
         Write-Verbose -Message "$($MyInvocation.MyCommand): get feed for $OperatingSystem."
         $updateFeed = Get-UpdateFeed -Uri $script:resourceStrings.UpdateFeeds.$OperatingSystem
@@ -61,6 +62,7 @@ Function Get-LatestServicingStackUpdate {
                         $Version = @($script:resourceStrings.ParameterValues.Windows10Versions[0])
                     }
                     ForEach ($ver in $Version) {
+
                         # Filter the feed for servicing stack updates and continue if we get updates
                         Write-Verbose -Message "$($MyInvocation.MyCommand): search feed for version $ver."
                         $gusParams = @{
@@ -71,6 +73,7 @@ Function Get-LatestServicingStackUpdate {
                         $updateList = Get-UpdateServicingStack @gusParams
         
                         If ($Null -ne $updateList) {
+
                             # Get download info for each update from the catalog
                             Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($update.Title)]."
                             $downloadInfoParams = @{
@@ -124,6 +127,7 @@ Function Get-LatestServicingStackUpdate {
                     Write-Verbose -Message "$($MyInvocation.MyCommand): update count is: $($updateList.Count)."
         
                     If ($Null -ne $updateList) {
+
                         # Get download info for each update from the catalog
                         Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($update.Title)]."
                         $downloadInfoParams = @{

--- a/LatestUpdate/Public/Get-LatestWindowsDefenderUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestWindowsDefenderUpdate.ps1
@@ -21,11 +21,13 @@ Function Get-LatestWindowsDefenderUpdate {
         $updateFeed = Get-UpdateFeed -Uri $script:resourceStrings.UpdateFeeds.WindowsDefender
 
         If ($Null -ne $updateFeed) {
+
             # Filter the feed for servicing stack updates and continue if we get updates
             $updateList = Get-UpdateDefender -UpdateFeed $updateFeed
             Write-Verbose -Message "$($MyInvocation.MyCommand): update count is: $($updateList.Count)."
 
             If ($Null -ne $updateList) {
+
                 # Get download info for each update from the catalog
                 Write-Verbose -Message "$($MyInvocation.MyCommand): searching catalog for: [$($update.Title)]."
                 $downloadInfoParams = @{

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -84,93 +84,99 @@ Function Save-LatestUpdate {
         [System.Management.Automation.SwitchParameter] $Force
     )
 
-    # Step through each update in $Updates
-    ForEach ($update in $Updates) {
+    Begin { }
 
-        # Manage updates with multiple URLs
-        ForEach ($url in $update.URL) {
+    Process {
+        # Step through each update in $Updates
+        ForEach ($update in $Updates) {
 
-            # Create the target file path where the update will be saved
-            $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
+            # Manage updates with multiple URLs
+            ForEach ($url in $update.URL) {
+
+                # Create the target file path where the update will be saved
+                $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
                 
-            # If the update is not already downloaded, download it.
-            If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
-                Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
-            }
-            Else {
-                If ($ForceWebRequest -or (Test-PSCore)) {
-                    If ($pscmdlet.ShouldProcess($url, "WebDownload")) {
-                        #Running on PowerShell Core or ForceWebRequest
-                        try {
-                            $iwrParams = @{
-                                Uri             = $url
-                                OutFile         = $updateDownloadTarget
-                                UseBasicParsing = $True
-                                ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
-                            }
-                            If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                $iwrParams.Proxy = $Proxy
-                            }
-                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                $iwrParams.ProxyCredentials = $ProxyCredential
-                            }
-                            Invoke-WebRequest @iwrParams
-                        }
-                        catch [System.Net.Http.HttpRequestException] {
-                            Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
-                            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-                        }
-                        catch [System.Net.WebException] {
-                            Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
-                            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-                        }
-                        catch [System.Exception] {
-                            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
-                            Throw $_.Exception.Message
-                        }
-                    }
+                # If the update is not already downloaded, download it.
+                If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
+                    Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
                 }
                 Else {
-                    If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
-                        #Running on Windows PowerShell
-                        try {
-                            $sbtParams = @{
-                                Source      = $url
-                                Destination = $updateDownloadTarget
-                                Priority    = $Priority
-                                DisplayName = $update.Note
-                                Description = "Downloading $url"
-                                ErrorAction = $script:resourceStrings.Preferences.ErrorAction
+                    If ($ForceWebRequest -or (Test-PSCore)) {
+                        If ($pscmdlet.ShouldProcess($url, "WebDownload")) {
+                            #Running on PowerShell Core or ForceWebRequest
+                            try {
+                                $iwrParams = @{
+                                    Uri             = $url
+                                    OutFile         = $updateDownloadTarget
+                                    UseBasicParsing = $True
+                                    ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
+                                }
+                                If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                    $iwrParams.Proxy = $Proxy
+                                }
+                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                    $iwrParams.ProxyCredentials = $ProxyCredential
+                                }
+                                Invoke-WebRequest @iwrParams
                             }
-                            If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                # Set priority to Foreground because the proxy will remove the Range protocol header
-                                $sbtParams.Priority = "Foreground"
-                                $sbtParams.ProxyUsage = "Override"
-                                $sbtParams.ProxyList = $Proxy
+                            catch [System.Net.Http.HttpRequestException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
                             }
-                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                $sbtParams.ProxyCredential = $ProxyCredentials
+                            catch [System.Net.WebException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
                             }
-                            Start-BitsTransfer @sbtParams
-                        }
-                        catch [System.Exception] {
-                            Write-Warning -Message "$($MyInvocation.MyCommand): Exception: check URL is valid: $url."
-                            Throw $_.Exception.Message
+                            catch [System.Exception] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
+                                Throw $_.Exception.Message
+                            }
                         }
                     }
-                }
-                If (Test-Path -Path $updateDownloadTarget) {
-                    $outputObject = [PSCustomObject] @{
-                        KB   = $update.KB
-                        Note = $update.Note
-                        Path = (Resolve-Path -Path $updateDownloadTarget)
+                    Else {
+                        If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
+                            #Running on Windows PowerShell
+                            try {
+                                $sbtParams = @{
+                                    Source      = $url
+                                    Destination = $updateDownloadTarget
+                                    Priority    = $Priority
+                                    DisplayName = $update.Note
+                                    Description = "Downloading $url"
+                                    ErrorAction = $script:resourceStrings.Preferences.ErrorAction
+                                }
+                                If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                    # Set priority to Foreground because the proxy will remove the Range protocol header
+                                    $sbtParams.Priority = "Foreground"
+                                    $sbtParams.ProxyUsage = "Override"
+                                    $sbtParams.ProxyList = $Proxy
+                                }
+                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                    $sbtParams.ProxyCredential = $ProxyCredentials
+                                }
+                                Start-BitsTransfer @sbtParams
+                            }
+                            catch [System.Exception] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): Exception: check URL is valid: $url."
+                                Throw $_.Exception.Message
+                            }
+                        }
                     }
-                    Write-Output -InputObject $outputObject
-                }
-                Else {
-                    Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
+                    If (Test-Path -Path $updateDownloadTarget) {
+                        $outputObject = [PSCustomObject] @{
+                            KB   = $update.KB
+                            Note = $update.Note
+                            Path = (Resolve-Path -Path $updateDownloadTarget)
+                        }
+                        Write-Output -InputObject $outputObject
+                    }
+                    Else {
+                        Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
+                    }
                 }
             }
         }
     }
+
+    End { }
 }

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -84,8 +84,6 @@ Function Save-LatestUpdate {
         [System.Management.Automation.SwitchParameter] $Force
     )
 
-    Begin { }
-
     Process {
         # Step through each update in $Updates
         ForEach ($update in $Updates) {
@@ -103,6 +101,7 @@ Function Save-LatestUpdate {
                 Else {
                     If ($ForceWebRequest -or (Test-PSCore)) {
                         If ($pscmdlet.ShouldProcess($url, "WebDownload")) {
+
                             #Running on PowerShell Core or ForceWebRequest
                             try {
                                 $iwrParams = @{
@@ -135,6 +134,7 @@ Function Save-LatestUpdate {
                     }
                     Else {
                         If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
+
                             #Running on Windows PowerShell
                             try {
                                 $sbtParams = @{
@@ -177,6 +177,4 @@ Function Save-LatestUpdate {
             }
         }
     }
-
-    End { }
 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -48,12 +48,13 @@ InModuleScope LatestUpdate {
                     $Output | Should -BeOfType ((Get-Command Get-LatestCumulativeUpdate).OutputType.Type.Name)
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
+                        $Update.Revision | Should -BeOfType System.String
                     }
                 }
             }
@@ -82,12 +83,12 @@ InModuleScope LatestUpdate {
                     $Output.Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -110,12 +111,12 @@ InModuleScope LatestUpdate {
                     $Output | Should -BeOfType ((Get-Command Get-LatestServicingStack).OutputType.Type.Name)
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -144,12 +145,12 @@ InModuleScope LatestUpdate {
                     $Output.Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -172,12 +173,12 @@ InModuleScope LatestUpdate {
                     $Output | Should -BeOfType ((Get-Command Get-LatestNetFrameworkUpdate).OutputType.Type.Name)
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -209,12 +210,12 @@ InModuleScope LatestUpdate {
                     $Output | Should -BeOfType ((Get-Command Get-LatestMonthlyRollup).OutputType.Type.Name)
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -243,12 +244,12 @@ InModuleScope LatestUpdate {
                     $Output.Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -271,12 +272,12 @@ InModuleScope LatestUpdate {
                     $Output | Should -BeOfType ((Get-Command Get-LatestAdobeFlashUpdate).OutputType.Type.Name)
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -303,12 +304,12 @@ InModuleScope LatestUpdate {
                 $Output | Should -BeOfType ((Get-Command Get-LatestAdobeFlashUpdate).OutputType.Type.Name)
             }
             ForEach ($Update in $Output) {
-                It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                    $Update.KB.Length | Should -BeGreaterThan 0
-                    $Update.Note.Length | Should -BeGreaterThan 0
-                    $Update.URL.Length | Should -BeGreaterThan 0
-                    $Update.Architecture.Length | Should -BeGreaterThan 0
-                    $Update.Version.Length | Should -BeGreaterThan 0
+                It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                    $Update.KB | Should -BeOfType System.String
+                    $Update.Note | Should -BeOfType System.String
+                    $Update.URL | Should -BeOfType System.String
+                    $Update.Architecture | Should -BeOfType System.String
+                    $Update.Version | Should -BeOfType System.String
                 }
             }
         }
@@ -336,12 +337,12 @@ InModuleScope LatestUpdate {
                     $Output.Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
-                    It "Returns a valid array with expected properties: [$($Update.Version), $($Update.Architecture)]" {
-                        $Update.KB.Length | Should -BeGreaterThan 0
-                        $Update.Note.Length | Should -BeGreaterThan 0
-                        $Update.URL.Length | Should -BeGreaterThan 0
-                        $Update.Architecture.Length | Should -BeGreaterThan 0
-                        $Update.Version.Length | Should -BeGreaterThan 0
+                    It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
+                        $Update.KB | Should -BeOfType System.String
+                        $Update.Note | Should -BeOfType System.String
+                        $Update.URL | Should -BeOfType System.String
+                        $Update.Architecture | Should -BeOfType System.String
+                        $Update.Version | Should -BeOfType System.String
                     }
                 }
             }
@@ -365,10 +366,10 @@ InModuleScope LatestUpdate {
                 $DefenderUpdates | Should -BeOfType ((Get-Command Get-LatestWindowsDefenderUpdate).OutputType.Type.Name)
             }
             ForEach ($Update in $DefenderUpdates) {
-                It "Given no arguments, returns a valid array with expected properties" {
-                    $Update.KB.Length | Should -BeGreaterThan 0
-                    $Update.Note.Length | Should -BeGreaterThan 0
-                    $Update.URL.Length | Should -BeGreaterThan 0
+                It "Given no arguments, Returns an array with expected property types" {
+                    $Update.KB | Should -BeOfType System.String
+                    $Update.Note | Should -BeOfType System.String
+                    $Update.URL | Should -BeOfType System.String
                 }
             }
         } 
@@ -395,9 +396,9 @@ InModuleScope LatestUpdate {
             }
             ForEach ($Download in $Downloads) {
                 It "Output from Save-LatestUpdate should have the expected properties" {
-                    $Download.KB.Length | Should -BeGreaterThan 0
-                    $Download.Note.Length | Should -BeGreaterThan 0
-                    $Download.Path.Length | Should -BeGreaterThan 0
+                    $Download.KB | Should -BeOfType System.String
+                    $Download.Note | Should -BeOfType System.String
+                    $Download.Path | Should -BeOfType System.String
                 }
             }
         }
@@ -425,9 +426,9 @@ InModuleScope LatestUpdate {
                     }
                     ForEach ($Download in $Downloads) {
                         It "Output from Save-LatestUpdate should have the expected properties" {
-                            $Download.KB.Length | Should -BeGreaterThan 0
-                            $Download.Note.Length | Should -BeGreaterThan 0
-                            $Download.Path.Length | Should -BeGreaterThan 0
+                            $Download.KB | Should -BeOfType System.String
+                            $Download.Note | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.String
                         }
                     }
                 }
@@ -453,9 +454,9 @@ InModuleScope LatestUpdate {
                     }
                     ForEach ($Download in $Downloads) {
                         It "Output from Save-LatestUpdate should have the expected properties" {
-                            $Download.KB.Length | Should -BeGreaterThan 0
-                            $Download.Note.Length | Should -BeGreaterThan 0
-                            $Download.Path.Length | Should -BeGreaterThan 0
+                            $Download.KB | Should -BeOfType System.String
+                            $Download.Note | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.String
                         }
                     }
                 }
@@ -481,9 +482,9 @@ InModuleScope LatestUpdate {
                     }
                     ForEach ($Download in $Downloads) {
                         It "Output from Save-LatestUpdate should have the expected properties" {
-                            $Download.KB.Length | Should -BeGreaterThan 0
-                            $Download.Note.Length | Should -BeGreaterThan 0
-                            $Download.Path.Length | Should -BeGreaterThan 0
+                            $Download.KB | Should -BeOfType System.String
+                            $Download.Note | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.String
                         }
                     }
                 }
@@ -509,9 +510,9 @@ InModuleScope LatestUpdate {
                     }
                     ForEach ($Download in $Downloads) {
                         It "Output from Save-LatestUpdate should have the expected properties" {
-                            $Download.KB.Length | Should -BeGreaterThan 0
-                            $Download.Note.Length | Should -BeGreaterThan 0
-                            $Download.Path.Length | Should -BeGreaterThan 0
+                            $Download.KB | Should -BeOfType System.String
+                            $Download.Note | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.String
                         }
                     }
                 }
@@ -533,9 +534,9 @@ InModuleScope LatestUpdate {
                 }
                 ForEach ($Download in $Downloads) {
                     It "Output from Save-LatestUpdate should have the expected properties" {
-                        $Download.KB.Length | Should -BeGreaterThan 0
-                        $Download.Note.Length | Should -BeGreaterThan 0
-                        $Download.Path.Length | Should -BeGreaterThan 0
+                        $Download.KB | Should -BeOfType System.String
+                        $Download.Note | Should -BeOfType System.String
+                        $Download.Path | Should -BeOfType System.String
                     }
                 }
             }
@@ -560,9 +561,9 @@ InModuleScope LatestUpdate {
                     }
                     ForEach ($Download in $Downloads) {
                         It "Output from Save-LatestUpdate should have the expected properties" {
-                            $Download.KB.Length | Should -BeGreaterThan 0
-                            $Download.Note.Length | Should -BeGreaterThan 0
-                            $Download.Path.Length | Should -BeGreaterThan 0
+                            $Download.KB | Should -BeOfType System.String
+                            $Download.Note | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.String
                         }
                     }
                 }
@@ -592,9 +593,9 @@ Context "Download via BITS Transfer" {
     }
     ForEach ($Download in $Downloads) {
         It "Output from Save-LatestUpdate should have the expected properties" {
-            $Download.KB.Length | Should -BeGreaterThan 0
-            $Download.Note.Length | Should -BeGreaterThan 0
-            $Download.Path.Length | Should -BeGreaterThan 0
+            $Download.KB | Should -BeOfType System.String
+            $Download.Note | Should -BeOfType System.String
+            $Download.Path | Should -BeOfType System.String
         }
     }
 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -398,7 +398,7 @@ InModuleScope LatestUpdate {
                 It "Output from Save-LatestUpdate should have the expected properties" {
                     $Download.KB | Should -BeOfType System.String
                     $Download.Note | Should -BeOfType System.String
-                    $Download.Path | Should -BeOfType System.String
+                    $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                 }
             }
         }
@@ -428,7 +428,7 @@ InModuleScope LatestUpdate {
                         It "Output from Save-LatestUpdate should have the expected properties" {
                             $Download.KB | Should -BeOfType System.String
                             $Download.Note | Should -BeOfType System.String
-                            $Download.Path | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                         }
                     }
                 }
@@ -456,7 +456,7 @@ InModuleScope LatestUpdate {
                         It "Output from Save-LatestUpdate should have the expected properties" {
                             $Download.KB | Should -BeOfType System.String
                             $Download.Note | Should -BeOfType System.String
-                            $Download.Path | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                         }
                     }
                 }
@@ -484,7 +484,7 @@ InModuleScope LatestUpdate {
                         It "Output from Save-LatestUpdate should have the expected properties" {
                             $Download.KB | Should -BeOfType System.String
                             $Download.Note | Should -BeOfType System.String
-                            $Download.Path | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                         }
                     }
                 }
@@ -512,7 +512,7 @@ InModuleScope LatestUpdate {
                         It "Output from Save-LatestUpdate should have the expected properties" {
                             $Download.KB | Should -BeOfType System.String
                             $Download.Note | Should -BeOfType System.String
-                            $Download.Path | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                         }
                     }
                 }
@@ -536,7 +536,7 @@ InModuleScope LatestUpdate {
                     It "Output from Save-LatestUpdate should have the expected properties" {
                         $Download.KB | Should -BeOfType System.String
                         $Download.Note | Should -BeOfType System.String
-                        $Download.Path | Should -BeOfType System.String
+                        $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                     }
                 }
             }
@@ -563,7 +563,7 @@ InModuleScope LatestUpdate {
                         It "Output from Save-LatestUpdate should have the expected properties" {
                             $Download.KB | Should -BeOfType System.String
                             $Download.Note | Should -BeOfType System.String
-                            $Download.Path | Should -BeOfType System.String
+                            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
                         }
                     }
                 }
@@ -595,7 +595,7 @@ Context "Download via BITS Transfer" {
         It "Output from Save-LatestUpdate should have the expected properties" {
             $Download.KB | Should -BeOfType System.String
             $Download.Note | Should -BeOfType System.String
-            $Download.Path | Should -BeOfType System.String
+            $Download.Path | Should -BeOfType System.Management.Automation.PathInfo
         }
     }
 }


### PR DESCRIPTION
# Description

* Added `Revision` property to `Get-LatestCumulativeUpdate` showing the Build and Revision of the cumulative update
* Added `Process` block to `Save-LatestUpdate` to ensure full pipeline support
* Updated Pester tests for `Revision` property and `Should -BeOfType` tests
* Updated code formatting and consistency across private and public functions

## Motivation and Context

* Viewing Build and Revision in latest Cumulative update can be used in scripts or tracking latest Windows 10 version numbers

## How Has This Been Tested?

* macOS, AppVeyor

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://github.com/aaronparker/docs/tree/master/LatestUpdate).
- [ ] I have updated the [documentation](https://github.com/aaronparker/docs/tree/master/LatestUpdate) accordingly.
- [ ] I have updated the [CHANGELOG](https://github.com/aaronparker/docs/blob/master/LatestUpdate/CHANGE-LOG.md) file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
