### PR TITLE
Added WindowsServer option to Get-LatestAdobeFlashUpdate

### DIFF
--- a/LatestUpdate/LatestUpdate.json
+++ b/LatestUpdate/LatestUpdate.json
@@ -32,6 +32,7 @@
     "Windows10" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-us/6ae59d69-36fc-8e4d-23dd-631d98bf74a9/atom",
     "Windows8" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-us/b905caa1-d413-c90c-bed3-20aead901092/atom",
     "Windows7" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-us/f825ca23-c7d1-aab8-4513-64980e1c3007/atom",
+    "WindowsServer" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-us/6ae59d69-36fc-8e4d-23dd-631d98bf74a9/atom",
     "NetFramework" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-us/df2c02f6-9610-d46d-2d76-fa570bd8c86a/atom",
     "WindowsDefender" : "https://support.microsoft.com/app/content/api/content/feeds/sap/en-au/5d4715e7-a9c9-378e-3f83-fd410db4ef0a/atom"
   },
@@ -53,7 +54,7 @@
       "Windows10", "Windows8", "Windows7"
     ],
     "Versions108" : [
-      "Windows10", "Windows8"
+      "Windows10", "Windows8", "WindowsServer"
     ],
     "Versions87" : [
       "Windows8", "Windows7"
@@ -62,7 +63,7 @@
       "Windows10", "WindowsClient", "WindowsServer"
     ],
     "VersionsComplete" : [
-    "Windows10", "Windows8", "Windows7", "WindowsClient", "WindowsServer", "All"
+      "Windows10", "Windows8", "Windows7", "WindowsClient", "WindowsServer", "All"
     ],
     "Windows10" : "Windows 10|Windows Server"
   },

--- a/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
@@ -72,10 +72,10 @@ Function Get-LatestAdobeFlashUpdate {
             }
             If ($Previous.IsPresent) { $gufParams.Previous = $True }
             $updateList = Get-UpdateAdobeFlash @gufParams
-            Write-Verbose -Message "$($MyInvocation.MyCommand): update count is: $($updateList.Count)."
+            Write-Verbose -Message "$($MyInvocation.MyCommand): update count is: $(($updateList | Measure-Object).count)."
 
             If ($Null -ne $updateList) {
-                Switch ($OperatingSystem) {
+                Switch -regex ($OperatingSystem) {
 
                     "Windows10" {
                         ForEach ($ver in $Version) {
@@ -113,7 +113,7 @@ Function Get-LatestAdobeFlashUpdate {
                         }
                     }
 
-                    "Windows8" {
+                    "Windows8|WindowsServer" {
                         If ($PSBoundParameters.ContainsKey('Version')) {
                             Write-Information -MessageData "INFO: The Version parameter is only valid for Windows10. Ignoring parameter." `
                                 -InformationAction Continue -Tags UserNotify

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -1,21 +1,51 @@
 Function Save-LatestUpdate {
     <#
         .SYNOPSIS
-            Downloads the latest Windows 10 Cumulative, Servicing Stack and Adobe Flash Player updates.
+            Downloads the updates passed from other LatestUpdate Get functions.
 
         .DESCRIPTION
-            Downloads the latest Windows 10 Cumulative, Servicing Stack and Adobe Flash Player updates to a local folder.
+            Downloads the updates passed from other LatestUpdate Get functions to a local folder.
+            
+            Use functions such as Get-LatestCumulativeUpdate and Get-LatestMonthlyRollup to retrieve the list of updates to then pass to Save-LatestUpdate to download each update locally. 
 
-            Then do one or more of the following:
-            - Import the update into an MDT share with Import-LatestUpdate to speed up deployment of Windows (reference images etc.)
+            Do one or more of the following with the downloaded updates:
+            - Import the update into an MDT share to speed deployment of Windows (new PCs, reference images etc.)
             - Apply the update to an offline WIM using DISM
             - Deploy the update with ConfigMgr (if not using WSUS)
+
+        .PARAMETER Updates
+            Specifies the list of updates from other LatestUpdate functions such as Get-LatestCumulativeUpdate and Get-LatestMonthlyRollup.
+
+        .PARAMETER Path
+            Specifies a path as the destination for the downloaded updates. All updates passed in -Updates will be downloaded to this path.
+
+        .PARAMETER ForceWebRequest
+            Forces the use of Invoke-WebRequest instead of Start-BitsTransfer when running under Windows PowerShell.
+
+        .PARAMETER Priority
+            Specifies the priority of a BITS transfer job. Defaults to Foreground. Foreground will enforced when proxy credentials are passed to Save-LatestUpdate
+
+        .PARAMETER Proxy
+            Specifies a proxy server address to use when initiating a download.
+
+        .PARAMETER ProxyCredential
+            Specifies a [System.Management.Automation.PSCredential] object to use when the proxy server requires authentication.
+
+        .PARAMETER Force
+            Specifies that existing downloaded updates will be re-downloaded and overwritten.
+
+        .EXAMPLE
+
+        PS C:\> $Updates = Get-LatestCumulativeUpdate
+        PS C:\> Save-LatestUpdate -Updates $Updates -Path C:\Temp\Updates
+
+        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Cumulative Updates. Save-LatestUpdate will download each returned update to C:\Temp\Updates.
 
         .EXAMPLE
 
         PS C:\> Get-LatestServicingStackUpdate | Save-LatestUpdate
 
-        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Servicing Stack Updates. The output is then passed to Save-LatestUpdate and each update is downloaded locally.
+        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Servicing Stack Updates. The output is then passed to Save-LatestUpdate and each update is downloaded to the current directory.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $True, HelpUri = "https://docs.stealthpuppy.com/docs/latestupdate/usage/download")]
@@ -24,11 +54,11 @@ Function Save-LatestUpdate {
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSObject] $Updates,
 
-        [Parameter(Mandatory = $False, Position = 1)]
+        [Parameter(Mandatory = $False, Position = 1, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 If (Test-Path -Path $_ -PathType 'Container') {
-                    return $true
+                    Return $true
                 }
                 Else {
                     Throw "Cannot find path $_"
@@ -37,137 +67,156 @@ Function Save-LatestUpdate {
         [System.String] $Path = $PWD,
 
         [Parameter(Mandatory = $False)]
-        [System.String] $Proxy,
-
-        [Parameter(Mandatory = $False)]
-        [System.Management.Automation.PSCredential]
-        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
-
-        [Parameter(Mandatory = $False)]
         [System.Management.Automation.SwitchParameter] $ForceWebRequest,
 
         [Parameter(Mandatory = $False)]
-        [validateset('BitsTransfer', 'WebRequest', 'WebClient')]
+        [validateset('BitsTransfer','WebRequest','WebClient')]
         [System.String] $Method = 'BitsTransfer',
 
         [Parameter(Mandatory = $False)]
         [ValidateSet('Foreground', 'High', 'Normal', 'Low')]
         [System.String] $Priority = "Foreground",
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
         
         [Parameter(Mandatory = $False)]
         [System.Management.Automation.SwitchParameter] $Force
     )
 
-    # Get module strings from the JSON
-    $resourceStrings = Get-ModuleResource
+    Process {
+        # Step through each update in $Updates
+        ForEach ($update in $Updates) {
 
-    # Output object
-    $downloadedUpdates = New-Object -TypeName System.Collections.ArrayList
+            # Manage updates with multiple URLs
+            ForEach ($url in $update.URL) {
 
-    # Step through each update in $Updates
-    ForEach ($update in $Updates) {
-
-        # Manage updates with multiple URLs
-        ForEach ($url in $update.URL) {
-
-            # Create the target file path where the update will be saved
-            $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
+                # Create the target file path where the update will be saved
+                $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
                 
-            # If the update is not already downloaded, download it.
-            If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
-                Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
-            }
-            Else {
-                If ($ForceWebRequest -or (Test-PSCore) -or ($pscmdlet.ShouldProcess($url, "WebDownload"))) {
-                    #Running on PowerShell Core or ForceWebRequest
-                    $Method = 'WebRequest'
-                }
-                If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
-                    $Method = 'BitsTransfer'
-                }
-                If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "WebClient")) {
-                    $Method = 'WebClient'
-                }
-
-                try {
-                    Switch ($Method) {
-                        'BitsTransfer' {
-                            # Running on Windows PowerShell
-                            $sbtParams = @{
-                                Source      = $url
-                                Destination = $updateDownloadTarget
-                                Priority    = $Priority
-                                DisplayName = $update.Note
-                                Description = "Downloading $url"
-                                ErrorAction = $resourceStrings.Preferences.ErrorAction
-                            }
-                            If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                # Set priority to Foreground because the proxy will remove the Range protocol header
-                                $sbtParams.Priority = "Foreground"
-                                $sbtParams.ProxyUsage = "Override"
-                                $sbtParams.ProxyList = $Proxy
-                            }
-                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                $sbtParams.ProxyCredential = $ProxyCredentials
-                            }
-                            Start-BitsTransfer @sbtParams
-                        }
-                        'WebRequest' {
-                            $iwrParams = @{
-                                Uri             = $url
-                                OutFile         = $updateDownloadTarget
-                                UseBasicParsing = $True
-                                ErrorAction     = $resourceStrings.Preferences.ErrorAction
-                            }
-                            If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                $iwrParams.Proxy = $Proxy
-                            }
-                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                $iwrParams.ProxyCredentials = $ProxyCredential
-                            }
-                            Invoke-WebRequest @iwrParams
-                        }
-                        'WebClient' {
-                            $webClient = New-Object System.Net.WebClient
-
-                            If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                $proxyObj = New-Object System.Net.WebProxy
-                                $proxyObj.Address = $Proxy
-                                
-                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                    $proxyObj.credentials = $ProxyCredential
-                                }
-
-                                $webClient.Proxy = $proxyObj
-                            }
-                            
-                            $webClient.DownloadFile($url, $updateDownloadTarget)
-                        }
-                    }
-                }
-                catch [System.Net.WebException] {
-                    Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-                }
-                catch [System.Exception] {
-                    Write-Warning -Message "$($MyInvocation.MyCommand): failed to download: $url."
-                    Throw $_.Exception.Message
-                }
-                
-                If (Test-Path -Path $updateDownloadTarget) {
-                    $PSObject = [PSCustomObject] @{
-                        KB   = $update.KB
-                        Note = $update.Note
-                        Path = (Resolve-Path -Path $updateDownloadTarget)
-                    }
-                    $downloadedUpdates.Add($PSObject) | Out-Null
+                # If the update is not already downloaded, download it.
+                If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
+                    Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
                 }
                 Else {
-                    Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
+                    If ($ForceWebRequest -or (Test-PSCore) -or ($pscmdlet.ShouldProcess($url, "WebDownload"))) {
+                        #Running on PowerShell Core or ForceWebRequest
+                        $Method = 'WebRequest'
+                    }
+                    If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
+                        $Method = 'BitsTransfer'
+                    }
+                    If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "WebClient")) {
+                        $Method = 'WebClient'
+                    }
+
+                    Switch ($Method) {
+                        'BitsTransfer' {
+                            #Running on Windows PowerShell
+                            try {
+                                $sbtParams = @{
+                                    Source      = $url
+                                    Destination = $updateDownloadTarget
+                                    Priority    = $Priority
+                                    DisplayName = $update.Note
+                                    Description = "Downloading $url"
+                                    ErrorAction = $script:resourceStrings.Preferences.ErrorAction
+                                }
+                                If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                    # Set priority to Foreground because the proxy will remove the Range protocol header
+                                    $sbtParams.Priority = "Foreground"
+                                    $sbtParams.ProxyUsage = "Override"
+                                    $sbtParams.ProxyList = $Proxy
+                                }
+                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                    $sbtParams.ProxyCredential = $ProxyCredentials
+                                }
+                                Start-BitsTransfer @sbtParams
+                            }
+                            catch [System.Exception] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): Exception: check URL is valid: $url."
+                                Throw $_.Exception.Message
+                            }
+                        }
+                        'WebRequest' {
+                            #Running on PowerShell Core or ForceWebRequest
+                            try {
+                                $iwrParams = @{
+                                    Uri             = $url
+                                    OutFile         = $updateDownloadTarget
+                                    UseBasicParsing = $True
+                                    ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
+                                }
+                                If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                    $iwrParams.Proxy = $Proxy
+                                }
+                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                    $iwrParams.ProxyCredentials = $ProxyCredential
+                                }
+                                Invoke-WebRequest @iwrParams
+                            }
+                            catch [System.Net.Http.HttpRequestException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                            }
+                            catch [System.Net.WebException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                            }
+                            catch [System.Exception] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
+                                Throw $_.Exception.Message
+                            }
+                        }
+                        'WebClient' {
+                            try {
+                                $webClient = New-Object System.Net.WebClient
+
+                                If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                    $proxyObj = New-Object System.Net.WebProxy
+                                    $proxyObj.Address = $Proxy
+                                    
+                                    If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                        $proxyObj.credentials = $ProxyCredential
+                                    }
+
+                                    $webClient.Proxy = $proxyObj
+                                }
+                                
+                                $webClient.DownloadFile($url, $updateDownloadTarget)
+                            }
+                            catch [System.Net.Http.HttpRequestException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                            }
+                            catch [System.Net.WebException] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
+                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                            }
+                            catch [System.Exception] {
+                                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
+                                Throw $_.Exception.Message
+                            }
+                        }
+                    }
+
+                    If (Test-Path -Path $updateDownloadTarget) {
+                        $outputObject = [PSCustomObject] @{
+                            KB   = $update.KB
+                            Note = $update.Note
+                            Path = (Resolve-Path -Path $updateDownloadTarget)
+                        }
+                        Write-Output -InputObject $outputObject
+                    }
+                    Else {
+                        Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
+                    }
                 }
             }
         }
     }
-
-    # Output results to the pipeline
-    Write-Output -InputObject $downloadedUpdates
 }

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -1,51 +1,21 @@
 Function Save-LatestUpdate {
     <#
         .SYNOPSIS
-            Downloads the updates passed from other LatestUpdate Get functions.
+            Downloads the latest Windows 10 Cumulative, Servicing Stack and Adobe Flash Player updates.
 
         .DESCRIPTION
-            Downloads the updates passed from other LatestUpdate Get functions to a local folder.
-            
-            Use functions such as Get-LatestCumulativeUpdate and Get-LatestMonthlyRollup to retrieve the list of updates to then pass to Save-LatestUpdate to download each update locally. 
+            Downloads the latest Windows 10 Cumulative, Servicing Stack and Adobe Flash Player updates to a local folder.
 
-            Do one or more of the following with the downloaded updates:
-            - Import the update into an MDT share to speed deployment of Windows (new PCs, reference images etc.)
+            Then do one or more of the following:
+            - Import the update into an MDT share with Import-LatestUpdate to speed up deployment of Windows (reference images etc.)
             - Apply the update to an offline WIM using DISM
             - Deploy the update with ConfigMgr (if not using WSUS)
-
-        .PARAMETER Updates
-            Specifies the list of updates from other LatestUpdate functions such as Get-LatestCumulativeUpdate and Get-LatestMonthlyRollup.
-
-        .PARAMETER Path
-            Specifies a path as the destination for the downloaded updates. All updates passed in -Updates will be downloaded to this path.
-
-        .PARAMETER ForceWebRequest
-            Forces the use of Invoke-WebRequest instead of Start-BitsTransfer when running under Windows PowerShell.
-
-        .PARAMETER Priority
-            Specifies the priority of a BITS transfer job. Defaults to Foreground. Foreground will enforced when proxy credentials are passed to Save-LatestUpdate
-
-        .PARAMETER Proxy
-            Specifies a proxy server address to use when initiating a download.
-
-        .PARAMETER ProxyCredential
-            Specifies a [System.Management.Automation.PSCredential] object to use when the proxy server requires authentication.
-
-        .PARAMETER Force
-            Specifies that existing downloaded updates will be re-downloaded and overwritten.
-
-        .EXAMPLE
-
-        PS C:\> $Updates = Get-LatestCumulativeUpdate
-        PS C:\> Save-LatestUpdate -Updates $Updates -Path C:\Temp\Updates
-
-        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Cumulative Updates. Save-LatestUpdate will download each returned update to C:\Temp\Updates.
 
         .EXAMPLE
 
         PS C:\> Get-LatestServicingStackUpdate | Save-LatestUpdate
 
-        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Servicing Stack Updates. The output is then passed to Save-LatestUpdate and each update is downloaded to the current directory.
+        This commands reads the the Windows 10 update history feed and returns an object that lists the most recent Windows 10 Servicing Stack Updates. The output is then passed to Save-LatestUpdate and each update is downloaded locally.
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $True, HelpUri = "https://docs.stealthpuppy.com/docs/latestupdate/usage/download")]
@@ -54,11 +24,11 @@ Function Save-LatestUpdate {
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSObject] $Updates,
 
-        [Parameter(Mandatory = $False, Position = 1, ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory = $False, Position = 1)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( {
                 If (Test-Path -Path $_ -PathType 'Container') {
-                    Return $true
+                    return $true
                 }
                 Else {
                     Throw "Cannot find path $_"
@@ -67,114 +37,137 @@ Function Save-LatestUpdate {
         [System.String] $Path = $PWD,
 
         [Parameter(Mandatory = $False)]
-        [System.Management.Automation.SwitchParameter] $ForceWebRequest,
-
-        [Parameter(Mandatory = $False)]
-        [ValidateSet('Foreground', 'High', 'Normal', 'Low')]
-        [System.String] $Priority = "Foreground",
-
-        [Parameter(Mandatory = $False)]
         [System.String] $Proxy,
 
         [Parameter(Mandatory = $False)]
         [System.Management.Automation.PSCredential]
         $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.SwitchParameter] $ForceWebRequest,
+
+        [Parameter(Mandatory = $False)]
+        [validateset('BitsTransfer', 'WebRequest', 'WebClient')]
+        [System.String] $Method = 'BitsTransfer',
+
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Foreground', 'High', 'Normal', 'Low')]
+        [System.String] $Priority = "Foreground",
         
         [Parameter(Mandatory = $False)]
         [System.Management.Automation.SwitchParameter] $Force
     )
 
-    Process {
-        # Step through each update in $Updates
-        ForEach ($update in $Updates) {
+    # Get module strings from the JSON
+    $resourceStrings = Get-ModuleResource
 
-            # Manage updates with multiple URLs
-            ForEach ($url in $update.URL) {
+    # Output object
+    $downloadedUpdates = New-Object -TypeName System.Collections.ArrayList
 
-                # Create the target file path where the update will be saved
-                $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
+    # Step through each update in $Updates
+    ForEach ($update in $Updates) {
+
+        # Manage updates with multiple URLs
+        ForEach ($url in $update.URL) {
+
+            # Create the target file path where the update will be saved
+            $updateDownloadTarget = Join-Path -Path $Path -ChildPath (Split-Path -Path $url -Leaf)
                 
-                # If the update is not already downloaded, download it.
-                If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
-                    Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
+            # If the update is not already downloaded, download it.
+            If ((Test-Path -Path $updateDownloadTarget) -and (-not $Force.IsPresent)) {
+                Write-Verbose -Message "File exists: $updateDownloadTarget. Skipping download."
+            }
+            Else {
+                If ($ForceWebRequest -or (Test-PSCore) -or ($pscmdlet.ShouldProcess($url, "WebDownload"))) {
+                    #Running on PowerShell Core or ForceWebRequest
+                    $Method = 'WebRequest'
+                }
+                If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
+                    $Method = 'BitsTransfer'
+                }
+                If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "WebClient")) {
+                    $Method = 'WebClient'
+                }
+
+                try {
+                    Switch ($Method) {
+                        'BitsTransfer' {
+                            # Running on Windows PowerShell
+                            $sbtParams = @{
+                                Source      = $url
+                                Destination = $updateDownloadTarget
+                                Priority    = $Priority
+                                DisplayName = $update.Note
+                                Description = "Downloading $url"
+                                ErrorAction = $resourceStrings.Preferences.ErrorAction
+                            }
+                            If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                # Set priority to Foreground because the proxy will remove the Range protocol header
+                                $sbtParams.Priority = "Foreground"
+                                $sbtParams.ProxyUsage = "Override"
+                                $sbtParams.ProxyList = $Proxy
+                            }
+                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                $sbtParams.ProxyCredential = $ProxyCredentials
+                            }
+                            Start-BitsTransfer @sbtParams
+                        }
+                        'WebRequest' {
+                            $iwrParams = @{
+                                Uri             = $url
+                                OutFile         = $updateDownloadTarget
+                                UseBasicParsing = $True
+                                ErrorAction     = $resourceStrings.Preferences.ErrorAction
+                            }
+                            If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                $iwrParams.Proxy = $Proxy
+                            }
+                            If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                $iwrParams.ProxyCredentials = $ProxyCredential
+                            }
+                            Invoke-WebRequest @iwrParams
+                        }
+                        'WebClient' {
+                            $webClient = New-Object System.Net.WebClient
+
+                            If ($PSBoundParameters.ContainsKey('Proxy')) {
+                                $proxyObj = New-Object System.Net.WebProxy
+                                $proxyObj.Address = $Proxy
+                                
+                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
+                                    $proxyObj.credentials = $ProxyCredential
+                                }
+
+                                $webClient.Proxy = $proxyObj
+                            }
+                            
+                            $webClient.DownloadFile($url, $updateDownloadTarget)
+                        }
+                    }
+                }
+                catch [System.Net.WebException] {
+                    Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                }
+                catch [System.Exception] {
+                    Write-Warning -Message "$($MyInvocation.MyCommand): failed to download: $url."
+                    Throw $_.Exception.Message
+                }
+                
+                If (Test-Path -Path $updateDownloadTarget) {
+                    $PSObject = [PSCustomObject] @{
+                        KB   = $update.KB
+                        Note = $update.Note
+                        Path = (Resolve-Path -Path $updateDownloadTarget)
+                    }
+                    $downloadedUpdates.Add($PSObject) | Out-Null
                 }
                 Else {
-                    If ($ForceWebRequest -or (Test-PSCore)) {
-                        If ($pscmdlet.ShouldProcess($url, "WebDownload")) {
-
-                            #Running on PowerShell Core or ForceWebRequest
-                            try {
-                                $iwrParams = @{
-                                    Uri             = $url
-                                    OutFile         = $updateDownloadTarget
-                                    UseBasicParsing = $True
-                                    ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
-                                }
-                                If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                    $iwrParams.Proxy = $Proxy
-                                }
-                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                    $iwrParams.ProxyCredentials = $ProxyCredential
-                                }
-                                Invoke-WebRequest @iwrParams
-                            }
-                            catch [System.Net.Http.HttpRequestException] {
-                                Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
-                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-                            }
-                            catch [System.Net.WebException] {
-                                Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
-                                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-                            }
-                            catch [System.Exception] {
-                                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
-                                Throw $_.Exception.Message
-                            }
-                        }
-                    }
-                    Else {
-                        If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "BitsDownload")) {
-
-                            #Running on Windows PowerShell
-                            try {
-                                $sbtParams = @{
-                                    Source      = $url
-                                    Destination = $updateDownloadTarget
-                                    Priority    = $Priority
-                                    DisplayName = $update.Note
-                                    Description = "Downloading $url"
-                                    ErrorAction = $script:resourceStrings.Preferences.ErrorAction
-                                }
-                                If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                    # Set priority to Foreground because the proxy will remove the Range protocol header
-                                    $sbtParams.Priority = "Foreground"
-                                    $sbtParams.ProxyUsage = "Override"
-                                    $sbtParams.ProxyList = $Proxy
-                                }
-                                If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                    $sbtParams.ProxyCredential = $ProxyCredentials
-                                }
-                                Start-BitsTransfer @sbtParams
-                            }
-                            catch [System.Exception] {
-                                Write-Warning -Message "$($MyInvocation.MyCommand): Exception: check URL is valid: $url."
-                                Throw $_.Exception.Message
-                            }
-                        }
-                    }
-                    If (Test-Path -Path $updateDownloadTarget) {
-                        $outputObject = [PSCustomObject] @{
-                            KB   = $update.KB
-                            Note = $update.Note
-                            Path = (Resolve-Path -Path $updateDownloadTarget)
-                        }
-                        Write-Output -InputObject $outputObject
-                    }
-                    Else {
-                        Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
-                    }
+                    Write-Warning -Message "$($MyInvocation.MyCommand): failed to download [$updateDownloadTarget]."
                 }
             }
         }
     }
+
+    # Output results to the pipeline
+    Write-Output -InputObject $downloadedUpdates
 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -42,7 +42,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Cumulative updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 It "Returns the expected output" {
                     $Output | Should -BeOfType ((Get-Command Get-LatestCumulativeUpdate).OutputType.Type.Name)
@@ -80,7 +80,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of previous Cumulative updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
                     It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
@@ -105,7 +105,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Servicing Stack updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 It "Returns the expected output" {
                     $Output | Should -BeOfType ((Get-Command Get-LatestServicingStack).OutputType.Type.Name)
@@ -142,7 +142,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of previous Servicing Stack updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
                     It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
@@ -167,7 +167,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of .NET Framework updates for $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 It "Returns the expected output" {
                     $Output | Should -BeOfType ((Get-Command Get-LatestNetFrameworkUpdate).OutputType.Type.Name)
@@ -204,7 +204,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Monthly Rollup updates for $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 It "Returns the expected output" {
                     $Output | Should -BeOfType ((Get-Command Get-LatestMonthlyRollup).OutputType.Type.Name)
@@ -241,7 +241,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Monthly Rollup updates for $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
                     It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {
@@ -266,7 +266,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Adobe Flash Player updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 It "Returns the expected output" {
                     $Output | Should -BeOfType ((Get-Command Get-LatestAdobeFlashUpdate).OutputType.Type.Name)
@@ -298,7 +298,7 @@ InModuleScope LatestUpdate {
             $Output = Get-LatestAdobeFlashUpdate -OperatingSystem Windows8
 
             It "Returns an array of 1 or more updates" {
-                $Output.Count | Should -BeGreaterThan 0
+                ($Output | Measure-Object).Count | Should -BeGreaterThan 0
             }
             It "Returns the expected output" {
                 $Output | Should -BeOfType ((Get-Command Get-LatestAdobeFlashUpdate).OutputType.Type.Name)
@@ -334,7 +334,7 @@ InModuleScope LatestUpdate {
 
             Context "Validate list of Adobe Flash Player updates for Windows 10 $Version" {
                 It "Returns an array of 1 or more updates" {
-                    $Output.Count | Should -BeGreaterThan 0
+                    ($Output | Measure-Object).Count | Should -BeGreaterThan 0
                 }
                 ForEach ($Update in $Output) {
                     It "Returns an array with expected property types: [$($Update.Version), $($Update.Architecture)]" {


### PR DESCRIPTION
# Description

With a few small changes I was able to alter the function to only return the Adobe Flash updates for Windows Server.

## Related Issue

https://github.com/aaronparker/LatestUpdate/issues/51

## Motivation and Context

Without these little changes, every update without a version in it's name is not returned.

## How Has This Been Tested?
Manually, and ran the pester tests

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6190791/63091193-e963b400-bf5d-11e9-9ce6-53f15fe6d1ab.png)


