### PR TITLE
Added proxy support

### DIFF
--- a/LatestUpdate/Private/Get-UpdateFeed.ps1
+++ b/LatestUpdate/Private/Get-UpdateFeed.ps1
@@ -10,7 +10,7 @@ Function Get-UpdateFeed {
         [ValidateNotNullOrEmpty()]
         [System.String] $Uri
     )
-    
+
     # Fix for Invoke-WebRequest creating BOM in XML files; Handle Temp locations on Windows, macOS / Linux
     If (Test-Path -Path env:Temp) {
         $tempDir = $env:Temp
@@ -31,16 +31,12 @@ Function Get-UpdateFeed {
         }
         Invoke-WebRequest @params
     }
-    catch [System.Net.Http.HttpRequestException] {
-        Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Failed to retrieve the update feed: $Uri."
-        Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-    }
     catch [System.Net.WebException] {
         Write-Warning -Message "$($MyInvocation.MyCommand): WebException: Failed to retrieve the update feed: $Uri."
         Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
     }
     catch [System.Exception] {
-        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to download: $url."
+        Write-Warning -Message "$($MyInvocation.MyCommand): Failed to retrieve the update feed: $url."
         Throw $_.Exception.Message
     }
     

--- a/LatestUpdate/Private/Set-Proxy.ps1
+++ b/LatestUpdate/Private/Set-Proxy.ps1
@@ -1,10 +1,10 @@
 Function Set-Proxy {
     <#
         .SYNOPSIS
-            Adds a property to a PSObject by querying another property
+            Sets proxy config for the session
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact='Medium')]
     Param (
         [Parameter(Mandatory = $False)]
         [System.String] $Proxy,
@@ -13,32 +13,54 @@ Function Set-Proxy {
         [System.Management.Automation.PSCredential] $ProxyCredential
     )
 
-    If ($Proxy) {
-        try {
-            $proxyUri = new-object System.Uri($Proxy)
+    Begin {
+        if (-not $PSBoundParameters.ContainsKey('Verbose')) {
+            $VerbosePreference = $PSCmdlet.SessionState.PSVariable.GetValue('VerbosePreference')
         }
-        catch {
-            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to convert proxy URI to system URI."
-            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-            Throw $_.Exception.Message
+        if (-not $PSBoundParameters.ContainsKey('Confirm')) {
+            $ConfirmPreference = $PSCmdlet.SessionState.PSVariable.GetValue('ConfirmPreference')
         }
-
-        try {
-            [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy ($proxyUri, $true)
+        if (-not $PSBoundParameters.ContainsKey('WhatIf')) {
+            $WhatIfPreference = $PSCmdlet.SessionState.PSVariable.GetValue('WhatIfPreference')
         }
-        catch {
-            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-            Throw $_.Exception.Message
-        }
+        Write-Verbose ('[{0}] Confirm={1} ConfirmPreference={2} WhatIf={3} WhatIfPreference={4}' -f $MyInvocation.MyCommand, $Confirm, $ConfirmPreference, $WhatIf, $WhatIfPreference)
     }
 
-    If ($ProxyCredential -ne [System.Management.Automation.PSCredential]::Empty) {
-        try {
-            [System.Net.WebRequest]::DefaultWebProxy.Credentials = $ProxyCredential
+    Process {
+        If ($Proxy) {
+            try {
+                $proxyUri = new-object System.Uri($Proxy)
+            }
+            catch {
+                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to convert proxy URI to system URI."
+                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                Throw $_.Exception.Message
+            }
+    
+            try {
+                if ($PSCmdlet.ShouldProcess("Configure proxy server?")) {
+                    Write-Verbose "Setting proxy server to $Proxy"
+                    [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy ($proxyUri, $true)
+                }
+                
+            }
+            catch {
+                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                Throw $_.Exception.Message
+            }
         }
-        catch {
-            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
-            Throw $_.Exception.Message
+    
+        If ($ProxyCredential -ne [System.Management.Automation.PSCredential]::Empty) {
+            try {
+                if ($PSCmdlet.ShouldProcess("Configure proxy credentials?")) {
+                    Write-Verbose "Configuring proxy credentials"
+                    [System.Net.WebRequest]::DefaultWebProxy.Credentials = $ProxyCredential
+                }
+            }
+            catch {
+                Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+                Throw $_.Exception.Message
+            }
         }
     }
 }

--- a/LatestUpdate/Private/Set-Proxy.ps1
+++ b/LatestUpdate/Private/Set-Proxy.ps1
@@ -1,0 +1,44 @@
+Function Set-Proxy {
+    <#
+        .SYNOPSIS
+            Adds a property to a PSObject by querying another property
+    #>
+    [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential] $ProxyCredential
+    )
+
+    If ($Proxy) {
+        try {
+            $proxyUri = new-object System.Uri($Proxy)
+        }
+        catch {
+            Write-Warning -Message "$($MyInvocation.MyCommand): Failed to convert proxy URI to system URI."
+            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+            Throw $_.Exception.Message
+        }
+
+        try {
+            [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy ($proxyUri, $true)
+        }
+        catch {
+            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+            Throw $_.Exception.Message
+        }
+    }
+
+    If ($ProxyCredential -ne [System.Management.Automation.PSCredential]::Empty) {
+        try {
+            [System.Net.WebRequest]::DefaultWebProxy.Credentials = $ProxyCredential
+        }
+        catch {
+            Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
+            Throw $_.Exception.Message
+        }
+    }
+}

--- a/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestAdobeFlashUpdate.ps1
@@ -54,8 +54,19 @@ Function Get-LatestAdobeFlashUpdate {
         [System.String[]] $Version = $script:resourceStrings.ParameterValues.Windows10Versions[0],
 
         [Parameter(Mandatory = $False)]
-        [System.Management.Automation.SwitchParameter] $Previous
+        [System.Management.Automation.SwitchParameter] $Previous,
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
     
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestCumulativeUpdate.ps1
@@ -50,8 +50,19 @@ Function Get-LatestCumulativeUpdate {
         [System.String[]] $Version = $script:resourceStrings.ParameterValues.Windows10Versions[0],
 
         [Parameter(Mandatory = $False)]
-        [System.Management.Automation.SwitchParameter] $Previous
+        [System.Management.Automation.SwitchParameter] $Previous,
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
     
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Get-LatestMonthlyRollup.ps1
+++ b/LatestUpdate/Public/Get-LatestMonthlyRollup.ps1
@@ -34,8 +34,19 @@ Function Get-LatestMonthlyRollup {
         [System.String] $OperatingSystem = $script:resourceStrings.ParameterValues.Versions87[0],
 
         [Parameter(Mandatory = $False)]
-        [System.Management.Automation.SwitchParameter] $Previous
+        [System.Management.Automation.SwitchParameter] $Previous,
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
     
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Get-LatestNetFrameworkUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestNetFrameworkUpdate.ps1
@@ -28,8 +28,19 @@ Function Get-LatestNetFrameworkUpdate {
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { $_ -in $script:resourceStrings.ParameterValues.VersionsComplete })]
         [Alias('OS')]
-        [System.String] $OperatingSystem = $script:resourceStrings.ParameterValues.VersionsComplete[0]
+        [System.String] $OperatingSystem = $script:resourceStrings.ParameterValues.VersionsComplete[0],
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
 
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Get-LatestServicingStackUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestServicingStackUpdate.ps1
@@ -44,8 +44,19 @@ Function Get-LatestServicingStackUpdate {
         [System.String[]] $Version,
 
         [Parameter(Mandatory = $False)]
-        [System.Management.Automation.SwitchParameter] $Previous
+        [System.Management.Automation.SwitchParameter] $Previous,
+
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
     )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
 
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Get-LatestWindowsDefenderUpdate.ps1
+++ b/LatestUpdate/Public/Get-LatestWindowsDefenderUpdate.ps1
@@ -14,7 +14,18 @@ Function Get-LatestWindowsDefenderUpdate {
     #>
     [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(HelpUri = "https://docs.stealthpuppy.com/docs/latestupdate/usage/get-defender")]
-    Param ()
+    Param (
+        [Parameter(Mandatory = $False)]
+        [System.String] $Proxy,
+
+        [Parameter(Mandatory = $False)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+        $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+    }
     
     # If resource strings are returned we can continue
     If ($Null -ne $script:resourceStrings) {

--- a/LatestUpdate/Public/Save-LatestUpdate.ps1
+++ b/LatestUpdate/Public/Save-LatestUpdate.ps1
@@ -83,10 +83,20 @@ Function Save-LatestUpdate {
         [Parameter(Mandatory = $False)]
         [System.Management.Automation.PSCredential]
         $ProxyCredential = [System.Management.Automation.PSCredential]::Empty,
+
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Basic', 'Digest', 'Ntlm', 'Negotiate', 'Passport')]
+        [System.String] $ProxyAuthentication = 'Negotiate',
         
         [Parameter(Mandatory = $False)]
         [System.Management.Automation.SwitchParameter] $Force
     )
+
+    Begin {
+        if ($PSBoundParameters.ContainsKey('Proxy') -or $PSBoundParameters.ContainsKey('ProxyCredential')) {
+            $null = Set-Proxy -Proxy $Proxy -ProxyCredential $ProxyCredential
+        }
+    }    
 
     Process {
         # Step through each update in $Updates
@@ -123,12 +133,13 @@ Function Save-LatestUpdate {
                                     }
                                     If ($PSBoundParameters.ContainsKey('Proxy')) {
                                         # Set priority to Foreground because the proxy will remove the Range protocol header
-                                        $sbtParams.Priority = "Foreground"
+                                        $sbtParams.Priority   = "Foreground"
                                         $sbtParams.ProxyUsage = "Override"
-                                        $sbtParams.ProxyList = $Proxy
+                                        $sbtParams.ProxyList  = $Proxy
                                     }
                                     If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                        $sbtParams.ProxyCredential = $ProxyCredentials
+                                        $sbtParams.ProxyAuthentication = $ProxyAuthentication
+                                        $sbtParams.ProxyCredential = $ProxyCredential
                                     }
                                     Start-BitsTransfer @sbtParams
                                 }
@@ -148,17 +159,7 @@ Function Save-LatestUpdate {
                                         UseBasicParsing = $True
                                         ErrorAction     = $script:resourceStrings.Preferences.ErrorAction
                                     }
-                                    If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                        $iwrParams.Proxy = $Proxy
-                                    }
-                                    If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                        $iwrParams.ProxyCredentials = $ProxyCredential
-                                    }
                                     Invoke-WebRequest @iwrParams
-                                }
-                                catch [System.Net.Http.HttpRequestException] {
-                                    Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
-                                    Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
                                 }
                                 catch [System.Net.WebException] {
                                     Write-Warning -Message "$($MyInvocation.MyCommand): WebException."
@@ -174,20 +175,7 @@ Function Save-LatestUpdate {
                             If ($pscmdlet.ShouldProcess($(Split-Path -Path $url -Leaf), "WebClient")) {
                                 try {
                                     $webClient = New-Object -TypeName System.Net.WebClient
-                                    If ($PSBoundParameters.ContainsKey('Proxy')) {
-                                        $proxyObj = New-Object -TypeName System.Net.WebProxy
-                                        $proxyObj.Address = $Proxy
-
-                                        If ($PSBoundParameters.ContainsKey('ProxyCredential')) {
-                                            $proxyObj.credentials = $ProxyCredential
-                                        }
-                                        $webClient.Proxy = $proxyObj
-                                    }
                                     $webClient.DownloadFile($url, $updateDownloadTarget)
-                                }
-                                catch [System.Net.Http.HttpRequestException] {
-                                    Write-Warning -Message "$($MyInvocation.MyCommand): HttpRequestException: Check URL is valid: $url."
-                                    Write-Warning -Message ([string]::Format("Error : {0}", $_.Exception.Message))
                                 }
                                 catch [System.Net.WebException] {
                                     Write-Warning -Message "$($MyInvocation.MyCommand): WebException."


### PR DESCRIPTION
# Description
Added proxy support on all commands. I added the Proxy and ProxyCredential parameter to all functions which then if given executes the private Set-Proxy function which sets the default proxy configuration for the script to use. This works for both Webrequest and Webclient. 

For Bitstranfer it still needs to get these parameters used in the commandline starting the download.
Because the Squid proxy server which I installed for testing only supports Basic authentication and bitstransfer by default uses 'negotiate', I added an extra parameter to the Save-LatestUpdate function to be able to set the ProxyAuthentication method.

This prevents having to change "all" the Invoke-Webrequests to use a created webclient object.

However, in the future if you want to have all the downloading done using webclient, I'd create a function called Get-WebClient which is started at the beginning of each public function and simply always add the proxy parameters and have that function return a webclient object with or without the proxy configured.

I also removed the catch for System.Net.Http.HttpRequestException as powershell gave errors on being unable to find this. It's also a bit too much to have 3 catches :P

## Related Issue
https://github.com/aaronparker/LatestUpdate/issues/16


## How Has This Been Tested?
I installed a Ubuntu server and configured Squid proxy server on it. This way I could use this server for testing.


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6190791/64066519-3b256300-cc1b-11e9-82cd-40c580c848d9.png)
![image](https://user-images.githubusercontent.com/6190791/64066523-3fea1700-cc1b-11e9-9ec6-f8d5b404142a.png)
![image](https://user-images.githubusercontent.com/6190791/64066524-437d9e00-cc1b-11e9-9691-6e024fde30a0.png)
